### PR TITLE
Readme: add Tips :: Match/replace the whole `body`

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,21 @@ Not supported yet
 (move)
 ```
 
+## Tips
+
+### Match/replace the whole `body`
+
+Kioo by default matches your selectors against `[:body :> any-node]` so you cannot match `:body` itself. 
+You should rarely need it – especially if you control the HTML and can wrap the content of body into 
+a `div` that you can then normally match against with Kioo. However, if necessary, you can also provide a custom root selector using the syntax `[<your selector> {<selectors and transforms>}]`, f.ex.: 
+
+```clojure
+(deftemplate tryme "some.html" [_] 
+  [:body] {[:body] (substitute (your-snippet-name _))})
+;;  ^- custom root selector
+;;           ^- inside the selected <body..>..</body>, match the body element itself
+ 
+```
 
 
 ## Thanks


### PR DESCRIPTION
I spent considerable time finding out why `(deftemplate ... {[:body] (content ..)})` does nothing and
would like to help other users avoid the same problem. (Though hopefully only few need it.)

For more info/background, see the blog post http://theholyjava.wordpress.com/2014/04/08/kioo-how-to-replace-the-whole-body/ (feedback warmly welcomed)
