### PR TITLE
Readme: Mention that e.g. first-of-type is a "naked symbol"

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ Enlive                                       CSS
 {[:dt] [:dl]}                                (fragments starting by DT and ending at the *next* DD)
 ```
 
+Notice that some of the predefined selector steps are used as naked symbols, i.e. 
+you can just use them (no require :refer etc.). Example:
+
+```clojure
+(defsnippet shop-html "templates/shops.html" [[:.shop first-of-type]]
+  [_] ;;                                                 ^- a naked symbol
+  {[:.content] (content "Kioo is mighty!")})
+```
+
 ## Transformations
 
 A transformation is a function that returns either a react node or collection of react nodes.


### PR DESCRIPTION
It took me a while to understand how to use the predef. selector types such as first-of-type.
(I have tried :first-of-type, (first-of-type), and searched for namespace to refer it from.)
It would be, I suppose, helpful to state explicitely that it is used just as a symbol.
