### PR TITLE
README correction. The location of the Enlive syntax.html doc has changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Once the javascript compiles you can open index.html in a browser.
 
 ### Selector Syntax
 
-Kioo uses enlive based selectors. See [syntax.html](http://enlive.cgrand.net/syntax.html)
+Kioo uses enlive based selectors. See [syntax.html](http://cgrand.github.io/enlive/syntax.html)
 
 Some examples:
 


### PR DESCRIPTION
Small change, but it might help others...
