### PR TITLE
Fix the warning/typo on the component member/method

### DIFF
--- a/src/kioo/util.cljx
+++ b/src/kioo/util.cljx
@@ -25,7 +25,7 @@
                      (when-let [f (aget (.-props this) "defaultProps")]
                        (binding [*component* this]
                          (f this)))))
-          :componentShouldUpdate
+          :shouldComponentUpdate
           (fn [next-props next-state]
             (this-as this
                      (when-let [f (aget (.-props this) "shouldUpdate")]
@@ -90,7 +90,7 @@
 
 
 (def attribute-map
-  (assoc 
+  (assoc
       (reduce #(assoc %1 (keyword (.toLowerCase (name %2))) %2) {}
               [:accessKey :allowFullScreen :allowTransparency :autoComplete
                :autoFocus :autoPlay :cellPadding :cellSpacing :charSet


### PR DESCRIPTION
I notice the warning message coming out of React's dev tools as I was using Kioo.

A quick inspection against Quiescent made me believe this was just a typo - https://github.com/levand/quiescent/blob/master/src/quiescent.cljs#L33
