### PR TITLE
Default whitespace suppression in om and reagent

### DIFF
--- a/src/kioo/om.clj
+++ b/src/kioo/om.clj
@@ -32,8 +32,9 @@
 
 
 (def om-emit-opts {:emit-trans emit-trans
-                      :emit-node emit-node
-                      :wrap-fragment wrap-fragment})
+                   :emit-node emit-node
+                   :wrap-fragment wrap-fragment
+                   :resource-wrapper :mini-html})
 
 
 (defmacro component

--- a/src/kioo/reagent.clj
+++ b/src/kioo/reagent.clj
@@ -20,7 +20,8 @@
 
 (def reagent-emit-opts {:emit-trans emit-trans
                         :emit-node emit-node
-                        :wrap-fragment wrap-fragment})
+                        :wrap-fragment wrap-fragment
+                        :resource-wrapper :mini-html})
 
 
 (defmacro component


### PR DESCRIPTION
I had some difficulty from whitespace suppression yesterday after upgrading to 0.4.1-SNAPSHOT expecting it to whitespace suppress by default. Turns out the react-emit-opts don't influence om-emit-opts or reagent-emit-opts and so the defaulting needs to be propogated to all three.
