### PR TITLE
Add microdata attributes

### DIFF
--- a/src/kioo/util.cljx
+++ b/src/kioo/util.cljx
@@ -95,11 +95,11 @@
               [:accessKey :allowFullScreen :allowTransparency :autoComplete
                :autoFocus :autoPlay :cellPadding :cellSpacing :charSet
                :colSpan :contentEditable :contextMenu :dateTime :encType
-               :formNoValidate :frameBorder :htmlFor :httpEquiv :maxLength
-               :noValidate :radioGroup :readOnly :rowSpan :scrollLeft :scrollTop
-               :spellCheck :srcDoc :tabIndex :gradientTransform :gradientUnits
-               :spreadMethod :stopColor :stopOpacity :strokeLinecap :strokeWidth
-               :textAnchor :viewBox])
+               :formNoValidate :frameBorder :htmlFor :httpEquiv :itemProp
+               :itemScope :itemType :maxLength :noValidate :radioGroup :readOnly
+               :rowSpan :scrollLeft :scrollTop :spellCheck :srcDoc :tabIndex
+               :gradientTransform :gradientUnits :spreadMethod :stopColor
+               :stopOpacity :strokeLinecap :strokeWidth :textAnchor :viewBox])
     :class
     :className))
 


### PR DESCRIPTION
Adds the `itemProp`, `itemScope` and `itemType` attributes. I haven't included `itemId` or `itemRef` because React does not (yet) support them.