### PR TITLE
Fixes unbound var error for Reagent version 0.5.0.

### DIFF
--- a/src/kioo/reagent.cljs
+++ b/src/kioo/reagent.cljs
@@ -1,7 +1,7 @@
 (ns kioo.reagent
   (:require [kioo.core :as core]
             [kioo.util :as util :refer [flatten-nodes]]
-            [reagent.impl.template :refer [as-component]]))
+            [reagent.core :refer [as-component]]))
 
 (defn make-dom [node]
   (let [rnode (if (map? node)
@@ -13,13 +13,13 @@
                    (seq? c) (reduce #(conj %1 (as-component %2))
                                     [(:tag node) (:attrs node)]
                                     c)
-                   :else [(:tag node) (:attrs node) c])) 
+                   :else [(:tag node) (:attrs node) c]))
                 node)]
     (as-component rnode)))
 
 
 (def content core/content)
-(def append core/append) 
+(def append core/append)
 (def prepend core/prepend)
 
 ;;after and before need to to make-dom


### PR DESCRIPTION
As of `[kioo "0.4.1-SNAPSHOT"]` the library is not working with `[reagent "0.5.0-alpha"]`, since reagent renamed the `as-component` function to `as-element-function`. There was an alias introduced for compatibility with older code, but it only extended for `react.core` namespace and not `reagen.impl.template` namespace.

Per this issue https://github.com/reagent-project/reagent/issues/93 issue suggested resolution was to stop relying on the `reagent.impl.template` namespace and use `reagent.core/as-component` alias instead. The `reagent.core/as-component` was introduced in version `0.4.0` (relevant commit - https://github.com/reagent-project/reagent/commit/ec7b9acf2389289acb1832854cee14a8a2e433fb) with intention of exposing `reagent.impl.template/as-component` which is supposedly private.
This limits the lower version bound of reagent usable with kioo to `0.4.0`, but since `project.clj` seem to list version `0.4.2` as a dependency it ultimately shouldn't be much of a problem.

The test seem to keep passing no problem, modified version seems to compile to usable reagent components.