### PR TITLE
Fixes compilation of predicates that nest another predicates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pom.xml.asc
 .#*.*
 *.*#
 *.*~
+.idea/
+*.iml

--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -78,7 +78,7 @@
   (reduce
    #(conj %1
           (cond
-           (list? %2) (apply (resolve-enlive-var (first %2)) (rest %2))
+           (list? %2) (apply (resolve-enlive-var (first %2)) (eval-selector (rest %2)))
            (or (vector? %2)
                (map? %2)
                (set? %2)) (eval-selector %2)

--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -76,14 +76,15 @@
 
 (defn eval-selector [sel]
   (reduce
-   #(conj %1
+    (fn [sel-acc sel-frag]
+      (conj sel-acc
           (cond
-           (list? %2) (apply (resolve-enlive-var (first %2)) (eval-selector (rest %2)))
-           (or (vector? %2)
-               (map? %2)
-               (set? %2)) (eval-selector %2)
-           (symbol? %2) (resolve-enlive-var %2)
-            :else %2))
+           (list? sel-frag) (apply (resolve-enlive-var (first sel-frag)) (eval-selector (rest sel-frag)))
+           (or (vector? sel-frag)
+               (map? sel-frag)
+               (set? sel-frag)) (eval-selector sel-frag)
+           (symbol? sel-frag) (resolve-enlive-var sel-frag)
+            :else sel-frag)))
    (cond
     (vector? sel) []
     (set? sel) #{}

--- a/test-resources/nested-has.html
+++ b/test-resources/nested-has.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Enlive test</title>
+</head>
+<body>
+<div class="form-group">
+    <input type="text" name="name"/>
+</div>
+</body>
+</html>

--- a/test/kioo/core_test.cljs
+++ b/test/kioo/core_test.cljs
@@ -4,7 +4,8 @@
                                remove-attr before after do->
                                set-style remove-style add-class
                                remove-class wrap unwrap set-class
-                               html html-content listen lifecycle]]
+                               html html-content listen lifecycle
+                               set-attr]]
             [kioo.test :refer [render-dom]]
             [goog.dom :as gdom])
   (:require-macros [kioo.core :refer [component  snippet template
@@ -235,3 +236,11 @@
                                                    (before "before")
                                                    (after "after"))}) ]
       (is (= "<span><span>before</span><div id=\"tmp\">success</div><span>after</span></span>" (render-dom comp))))))
+
+(deftemplate nested-has-template "nested-has.html" []
+             {[[:.form-group (has [[:input (attr= :name "name")]])]] (set-attr :id "test")})
+
+(deftest nested-has-test
+         (testing "nested has selector"
+                  (is (= (render-dom (nested-has-template))
+                         "<div class=\"form-group\" id=\"test\"><input name=\"name\" type=\"text\"></div>"))))

--- a/test/kioo/om_test.cljs
+++ b/test/kioo/om_test.cljs
@@ -4,7 +4,7 @@
                              remove-attr before after do->
                              set-style remove-style add-class
                              remove-class wrap unwrap set-class
-                             html html-content listen]]
+                             html html-content listen set-attr]]
             [kioo.test :refer [render-dom]]
             [goog.dom :as gdom])
   (:require-macros [kioo.om :refer [component snippet template
@@ -192,3 +192,11 @@
                                                    (after "after"))}) ]
       (is (= "<span><span>before</span><div id=\"tmp\">success</div><span>after</span></span>"
              (render-dom comp))))))
+
+(deftemplate nested-has-template "nested-has.html" []
+             {[[:.form-group (has [[:input (attr= :name "name")]])]] (set-attr :id "test")})
+
+(deftest nested-has-test
+         (testing "nested has selector"
+                  (is (= (render-dom (nested-has-template))
+                         "<div class=\"form-group\" id=\"test\"><input name=\"name\" type=\"text\"></div>"))))

--- a/test/kioo/reagent_test.cljs
+++ b/test/kioo/reagent_test.cljs
@@ -4,7 +4,7 @@
                                remove-attr before after do->
                                set-style remove-style add-class
                                remove-class wrap unwrap set-class
-                               html html-content listen]]
+                               html html-content listen set-attr]]
             [reagent.core :as reagent :refer [atom flush]]
             [kioo.util :as util]
             [goog.dom :as gdom])
@@ -226,3 +226,11 @@
                                                    (after "after"))}) ]
       (is (= "<span><span>before</span><div id=\"tmp\">success</div><span>after</span></span>"
              (render-dom comp))))) )
+
+(deftemplate nested-has-template "nested-has.html" []
+             {[[:.form-group (has [[:input (attr= :name "name")]])]] (set-attr :id "test")})
+
+(deftest nested-has-test
+         (testing "nested has selector"
+                  (is (= (render-dom nested-has-template)
+                         "<div class=\"form-group\" id=\"test\"><input name=\"name\" type=\"text\"></div>"))))


### PR DESCRIPTION
Right now using a selector like this
```
[[:div (has [[:div (attr= :a "b"]])]]
```
results in a compilation error during macro expansion (example: https://gist.github.com/jaen/ca61d108e20194009338) due to the inner predicate symbol not being resolved to an appropriate enlive var like the outer predicate symbol is.

I changed symbol resolution in predicate expressions inside the selectors to be recursive to fix this issue.

I've added some tests for this issue, but I'm not sure if it's the best way to test for it.  
Since the issue manifests itself during macro expansion you won't get a test failure but a test error. Probably the best way would be to test if `kioo.core/eval-selector` leaves any non-resolved symbols in it's output or not.
I can add such a test later if you think it's important to test this before merging, though some pointers how to do it would be appreciated.