### PR TITLE
Fix transformation of HTML "for" attribute

### DIFF
--- a/src/kioo/server/core.clj
+++ b/src/kioo/server/core.clj
@@ -36,6 +36,7 @@
 (defn attr-by-key [ky]
   (case ky
     :className "class"
+    :htmlFor   "for"
     (name ky)))
 
 (defn emit-attrs [attrs]

--- a/src/kioo/util.cljx
+++ b/src/kioo/util.cljx
@@ -95,13 +95,13 @@
               [:accessKey :allowFullScreen :allowTransparency :autoComplete
                :autoFocus :autoPlay :cellPadding :cellSpacing :charSet
                :colSpan :contentEditable :contextMenu :dateTime :encType
-               :formNoValidate :frameBorder :htmlFor :httpEquiv :itemProp
+               :formNoValidate :frameBorder :httpEquiv :itemProp
                :itemScope :itemType :maxLength :noValidate :radioGroup :readOnly
                :rowSpan :scrollLeft :scrollTop :spellCheck :srcDoc :tabIndex
                :gradientTransform :gradientUnits :spreadMethod :stopColor
                :stopOpacity :strokeLinecap :strokeWidth :textAnchor :viewBox])
-    :class
-    :className))
+    :class :className
+    :for   :htmlFor))
 
 (defn transform-keys [attrs]
   (reduce (fn [m [k v]]


### PR DESCRIPTION
The React docs say that not only the HTML "class" attribute becomes
"className" in JSX, but also "for" becomes "htmlFor" [1]. The first one
was already implemented in Kioo, the second not. Implement it.

Note that this is not tested, yet, since I couldn't get the build to run
on my system.

[1] https://facebook.github.io/react/docs/tags-and-attributes.html

The error I'm getting is this:

```
$ lein cljsbuild test
WARNING!!! version ranges found for:
[com.keminglabs/cljx "0.3.2"] -> [org.clojars.trptcolin/sjacket "0.1.0.3"] -> [org.clojure/clojure "[1.3.0,)"]
Consider using [com.keminglabs/cljx "0.3.2" :exclusions [org.clojure/clojure]].
[com.keminglabs/cljx "0.3.2"] -> [org.clojars.trptcolin/sjacket "0.1.0.3"] -> [net.cgrand/regex "1.1.0"] -> [org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.3.2" :exclusions [org.clojure/clojure]].
[com.keminglabs/cljx "0.3.2"] -> [org.clojars.trptcolin/sjacket "0.1.0.3"] -> [net.cgrand/parsley "0.9.1"] -> [org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.3.2" :exclusions [org.clojure/clojure]].
[com.keminglabs/cljx "0.3.2"] -> [org.clojars.trptcolin/sjacket "0.1.0.3"] -> [net.cgrand/parsley "0.9.1"] -> [net.cgrand/regex "1.1.0"] -> [org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.3.2" :exclusions [org.clojure/clojure]].

Compiling ClojureScript.
Compiling "target/test/kioo.js" from ["test" "target/classes" "target/test-classes"]...
Compiling "target/test/kioo.js" failed.
java.io.FileNotFoundException: target/test-classes (Datei oder Verzeichnis nicht gefunden)
        at java.io.FileInputStream.open(Native Method)
        at java.io.FileInputStream.<init>(FileInputStream.java:146)
        at clojure.java.io$fn__8702.invoke(io.clj:229)
        at clojure.java.io$fn__8615$G__8606__8622.invoke(io.clj:69)
        at clojure.java.io$fn__8676.invoke(io.clj:165)
... 
```

I did run `lein cljx once` before.