### PR TITLE
Fix more HTML attributes

### DIFF
--- a/src/kioo/server/core.clj
+++ b/src/kioo/server/core.clj
@@ -35,8 +35,9 @@
 
 (defn attr-by-key [ky]
   (case ky
-    :className "class"
-    :htmlFor   "for"
+    :acceptCharset "accept-charset"
+    :className     "class"
+    :htmlFor       "for"
     (name ky)))
 
 (defn emit-attrs [attrs]

--- a/src/kioo/util.cljx
+++ b/src/kioo/util.cljx
@@ -95,13 +95,14 @@
               [:accessKey :allowFullScreen :allowTransparency :autoComplete
                :autoFocus :autoPlay :cellPadding :cellSpacing :charSet
                :colSpan :contentEditable :contextMenu :dateTime :encType
-               :formNoValidate :frameBorder :httpEquiv :itemProp
+               :formEncType :formNoValidate :frameBorder :httpEquiv :itemProp
                :itemScope :itemType :maxLength :noValidate :radioGroup :readOnly
                :rowSpan :scrollLeft :scrollTop :spellCheck :srcDoc :tabIndex
                :gradientTransform :gradientUnits :spreadMethod :stopColor
                :stopOpacity :strokeLinecap :strokeWidth :textAnchor :viewBox])
-    :class :className
-    :for   :htmlFor))
+    :accept-charset :acceptCharset
+    :class          :className
+    :for            :htmlFor))
 
 (defn transform-keys [attrs]
   (reduce (fn [m [k v]]


### PR DESCRIPTION
Apparently it's not only "class" and "for" that can't be converted
between JSX and HTML automatically, but other attributes as well.
Add accept-charset/acceptCharset to the manual conversions. Add
formEncType to the list of auto-convertible attributes. There are
probably some more things missing, but I don't have the nerve to go
through the HTML and JSX spec right now.