### PR TITLE
Allow templates from sources other than classpath resources

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,10 +8,12 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[enlive "1.1.5"]
                  [com.facebook/react "0.11.1"]
+                 [cljsjs/react "0.13.1-0"]
                  [org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2280"]
+                 [org.clojure/clojurescript "0.0-3211"]
                  [com.googlecode.htmlcompressor/htmlcompressor "1.5.2"]
                  [sablono "0.2.20"]
+                 [sablono "0.3.4"]
                  [hickory "0.5.3"]
                  [om "0.7.1"]
                  [reagent "0.4.2"]
@@ -26,7 +28,7 @@
     ["cljsbuild" "auto" "test"]]}
   :cljsbuild {:builds []}
   :profiles {:dev {:plugins [[com.keminglabs/cljx "0.3.2"] ;; Must be before Austin: https://github.com/cemerick/austin/issues/37
-                             [com.cemerick/austin "0.1.3"]
+                             #_[com.cemerick/austin "0.1.3"]
                              [com.cemerick/clojurescript.test "0.3.2-SNAPSHOT"]
                              [lein-cljsbuild "1.0.4-SNAPSHOT"]
                              [lein-ancient "0.5.4"]]

--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -104,11 +104,6 @@
    (symbol? wrapper) (resolve wrapper)
    :else parser/->MiniHtml))
 
-
-(defn path-exists? [path]
-  (or (not (string? path))
-      (io/resource path)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main Structure of Compiler
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -127,8 +122,6 @@
   ([path trans emit-opts]
      (component* path [:body :> any-node] trans emit-opts))
   ([path sel trans emit-opts]
-     (assert (path-exists? path) (str "No resource found for: '" path
-                                      "' - kioo pulls resources from the class path"))
      (let [resource-fn (resolve-resource-fn path emit-opts)
            root (parse-html path resource-fn)
            start (if (= :root sel)

--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -122,8 +122,9 @@
   ([path trans emit-opts]
      (component* path [:body :> any-node] trans emit-opts))
   ([path sel trans emit-opts]
-     (let [resource-fn (resolve-resource-fn path emit-opts)
-           root (parse-html path resource-fn)
+     (let [path-obj (eval path)
+           resource-fn (resolve-resource-fn path-obj emit-opts)
+           root (parse-html path-obj resource-fn)
            start (if (= :root sel)
                     root
                     (select root (eval-selector sel)))

--- a/src/kioo/core.cljs
+++ b/src/kioo/core.cljs
@@ -22,7 +22,7 @@
                                     (aget (.-props this) "value")
                                     (aget (.-props this) "statics")))))})]
     (fn [value & static-args]
-      (react-component #js {:value value :statics static-args}))))
+      (.createElement js/React react-component #js {:value value :statics static-args}))))
 
 
 (defn make-dom [node]

--- a/src/kioo/util.cljx
+++ b/src/kioo/util.cljx
@@ -1,6 +1,7 @@
 (ns kioo.util
   (:refer-clojure :exclude [replace])
-  (:require [clojure.string :refer [split replace capitalize]]))
+  (:require [clojure.string :refer [split replace capitalize]]
+            #+cljs [cljsjs.react]))
 
 #+cljs
 (def ^:dynamic *component* nil)


### PR DESCRIPTION
Sometimes it is useful to load a template from a location other than a classpath resource. This might be an external URL, or a file on the file system that is not on the  classpath (for whatever reason.)

In my particular use case, I am loading templates from a local Middleman development server, where designers can write markup directly with the full suite of Ruby tools which can then get dynamically pulled into my Clojurescript at CLJS compile time.

The only substantive changes is to call `eval` on the `path` form. If it is a string, it evaluates to a string and everything works exactly the way it did. Otherwise, it may be any form which, when evaluated in Clojure, will return an object that can be passed to `net.cgrand.enlive-html/get-resource`, which includes URLs, Files, Readers, etc.

The only other changes in this PR are minor, minimal changes to get it working with React 13+.