### PR TITLE
Compile-time transformations check

### DIFF
--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -131,6 +131,12 @@
            child-sym (gensym "ch")]
         (assert (or (empty? trans) (map? trans))
                 "Transforms must be a map - Kioo only supports order independent transforms")
+        (doseq [trans-selector (keys trans)]
+          (if (empty? (select start (eval-selector trans-selector)))
+            (let [message (format "File %s does not contain selector %s %s."
+                                  path sel trans-selector)]
+              (throw (AssertionError. message)))))
+
         `(let [~child-sym ~(compile (map-trans start trans) emit-opts)]
            (if (= 1 (count ~child-sym))
              (first ~child-sym)

--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -135,7 +135,11 @@
           (if (empty? (select start (eval-selector trans-selector)))
             (let [message (format "File %s does not contain selector %s %s."
                                   path sel trans-selector)]
-              (throw (AssertionError. message)))))
+              (try
+                (throw (AssertionError. message))
+                (catch AssertionError e
+                  (binding [*out* *err*]
+                    (println message)))))))
 
         `(let [~child-sym ~(compile (map-trans start trans) emit-opts)]
            (if (= 1 (count ~child-sym))

--- a/test/kioo/server/core_test.clj
+++ b/test/kioo/server/core_test.clj
@@ -13,7 +13,18 @@
  (testing "basic render test"
     (let [comp (component "simple-div.html" {}) ]
       (is (= "<div id=\"tmp\">test</div>" comp))))
- 
+
+  (testing "compile-time error"
+    (let [message
+          (try
+            (with-out-str
+              (binding [*err* *out*]
+                (macroexpand `(component "simple-div.html"
+                                         {[:diw] (content "success")}))))
+            (catch AssertionError e
+              (.getMessage e)))]
+      (is (re-find #"File .* does not contain selector" message))))
+
   (testing "content replace"
     (let [comp (component "simple-div.html" 
                           {[:div] (content "success")})]


### PR DESCRIPTION
Ensure all selectors in transformations block are present in selected html fragment. This will help to ensure that html you've received from html guy is still compatible with your component definitions and you won't get 'lorem ipsum' not replaced in production and won't get missing functionality (placing component/data inside non-existent div).