### PR TITLE
Project setup fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,16 +7,15 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[enlive "1.1.5"]
-                 [com.facebook/react "0.11.1"]
-                 [cljsjs/react "0.13.1-0"]
+                 [cljsjs/react "0.12.2-5"]
                  [org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-3211"]
                  [com.googlecode.htmlcompressor/htmlcompressor "1.5.2"]
                  [sablono "0.2.20"]
                  [sablono "0.3.4"]
                  [hickory "0.5.3"]
-                 [om "0.7.1"]
-                 [reagent "0.4.2"]
+                 [om "0.7.1" :exclusions [com.facebook/react]]
+                 [reagent "0.5.0" :exclusions [cljsjs/react]]
                  [enlive-ws  "0.1.1"]]
   :plugins [[lein-cljsbuild "1.0.4-SNAPSHOT"]
             [lein-shell "0.4.0"]]
@@ -57,9 +56,7 @@
                                          :compiler {:output-to "target/test/kioo.js"
                                                     :optimizations :simple
                                                     :pretty-print true
-                                                    :preamble ["phantomjs-shims.js"
-                                                               "react/react.js"]
-                                                    :externs ["react/externs/react.js"]}}]
+                                                    :preamble ["phantomjs-shims.js" ]}}]
                                :test-commands {"phantom" ["phantomjs" :runner "target/test/kioo.js"]}}
                    :repl-options {:nrepl-middleware [cljx.repl-middleware/wrap-cljx]}
                    :resource-paths ["test-resources"]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,6 @@
                  [org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-3211"]
                  [com.googlecode.htmlcompressor/htmlcompressor "1.5.2"]
-                 [sablono "0.2.20"]
                  [sablono "0.3.4"]
                  [hickory "0.5.3"]
                  [om "0.7.1" :exclusions [com.facebook/react]]


### PR DESCRIPTION
Currently cloning a repo and runing `lein auto-test` leads to weird errors:

```
Compiling ClojureScript.
Compiling "target/test/kioo.js" from ["src" "test" "target/classes" "target/test-classes"]...
Jun 05, 2015 4:27:29 PM com.google.javascript.jscomp.LoggerErrorManager println
SEVERE: file:/home/me/.m2/repository/cljsjs/react/0.13.1-0/react-0.13.1-0.jar!/cljsjs/common/react.ext.js:11: ERROR - constant React assigned a value more than once.
Original definition at file:/home/me/.m2/repository/com/facebook/react/0.11.1/react-0.11.1.jar!/react/externs/react.js:12
var React = {};
^

Jun 05, 2015 4:27:29 PM com.google.javascript.jscomp.LoggerErrorManager printSummary
WARNING: 1 error(s), 0 warning(s)
ERROR: JSC_CONSTANT_REASSIGNED_VALUE_ERROR. constant React assigned a value more than once.
Original definition at file:/home/me/.m2/repository/com/facebook/react/0.11.1/react-0.11.1.jar!/react/externs/react.js:12 at file:/home/me/.m2/repository/cljsjs/react/0.13.1-0/react-0.13.1-0.jar!/cljsjs/common/react.ext.js line 11 : 0
SyntaxError: Expected an identifier but found 'compiled' instead

  phantomjs://webpage.evaluate():1 in evaluateJavaScript

ERROR: cemerick.cljs.test was not required.

You can resolve this issue by ensuring [cemerick.cljs.test] appears
in the :require clause of your test suite namespaces.
Also make sure that your build has actually included any test files.


  /tmp/runner1179346817260289822.js:36 in onError
```

It turned out that this errors were due different versions of react being imported simultaneously (one from project.clj and other from om/reagent dependencies). After dropping react from project.clj it works fine.