### PR TITLE
if selector matches 2+ elements allow to use just first one

### DIFF
--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -45,6 +45,7 @@
 (def react-emit-opts {:emit-trans emit-trans
                       :emit-node emit-node
                       :wrap-fragment wrap-fragment
+                      :single false
                       :resource-wrapper :mini-html})
 
 (defmacro component
@@ -128,12 +129,17 @@
      (component* path [:body :> any-node] trans emit-opts))
   ([path sel trans emit-opts]
      (let [path-obj (eval path)
+           single? (:single emit-opts)
+           emit-opts (dissoc emit-opts :single)
            resource-fn (resolve-resource-fn path-obj emit-opts)
            ast-fn (:process-ast emit-opts)
            root (parse-html path-obj resource-fn ast-fn)
-           start (if (= :root sel)
-                    root
-                    (select root (eval-selector sel)))
+           start-matches (if (= :root sel)
+                           root
+                           (select root (eval-selector sel)))
+           start (if single?
+                   (take 1 start-matches)
+                   start-matches)
            child-sym (gensym "ch")]
         (assert (or (empty? trans) (map? trans))
                 "Transforms must be a map - Kioo only supports order independent transforms")

--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -121,6 +121,10 @@
    (let [ast-fn (or ast-fn identity)]
      (ast-fn (parse-html path resource-fn)))))
 
+(defn- warning! [format-string & args]
+  (binding [*out* *err*]
+    (println (apply format (str "WARNING: " format-string) args))))
+
 (defn component*
   "this is the generic component that takes emitter
    options that define how the component is mapped
@@ -145,13 +149,7 @@
                 "Transforms must be a map - Kioo only supports order independent transforms")
         (doseq [trans-selector (keys trans)]
           (if (empty? (select start (eval-selector trans-selector)))
-            (let [message (format "WARNING: File %s does not contain selector %s %s."
-                                  path sel trans-selector)]
-              (try
-                (throw (AssertionError. message))
-                (catch AssertionError e
-                  (binding [*out* *err*]
-                    (println message)))))))
+            (warning! "File %s does not contain selector %s %s." path sel trans-selector)))
 
         `(let [~child-sym ~(compile (map-trans start trans) emit-opts)]
            (if (= 1 (count ~child-sym))

--- a/test/kioo/core_test.cljs
+++ b/test/kioo/core_test.cljs
@@ -24,6 +24,9 @@
   (testing "first-of-type naked symbol"
     (let [comp (component "list.html" [:ul [:li first-of-type]] {})]
       (is (= "<li>1</li>" (render-dom comp)))))
+  (testing "multiple match should render first match"
+    (let [comp (component "list.html" [:ul :li] {} {:single true})]
+      (is (= "<li>1</li>" (render-dom comp)))))
   (testing "attr= content replace"
     (let [comp (component "simple-attr-div.html"
                           {[(attr= :data-id "tmp")]


### PR DESCRIPTION
In CSS there's no way to say "first element that matches this selector" - there's only first-child and the like. Often there are cases when you have collection with elements of different kinds and you wish to take just one of its kind and make component from it. Without this change the component would consist of all elements of such kind found in html.
