### PR TITLE
Added tests to demonstrate poor performance on Safari (also applies in Phantom.js)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,8 @@
                  [reagent "0.5.0" :exclusions [cljsjs/react]]
                  [enlive-ws  "0.1.1"]]
   :plugins [[lein-cljsbuild "1.0.4-SNAPSHOT"]
-            [lein-shell "0.4.0"]]
+            [lein-shell "0.4.0"]
+            [lein-marginalia "0.8.0"]]
   :aliases
   {"auto-test"
    ["do" "clean"

--- a/test-resources/min-form.html
+++ b/test-resources/min-form.html
@@ -1,3 +1,5 @@
+<html>
+<body>
 <div class="outcomes">
     <h2>Outcomes</h2>
     <form>
@@ -12,3 +14,5 @@
         </fieldset>
     </form>
 </div>
+</body>
+</html>

--- a/test-resources/min-form.html
+++ b/test-resources/min-form.html
@@ -1,0 +1,14 @@
+<div class="outcomes">
+    <h2>Outcomes</h2>
+    <form>
+        <fieldset>
+            <legend>Outcomes assessment</legend>
+            <div>
+                <div>
+                    <label for="test">Test label</label>
+                    <input id="test" type="date">
+                </div>
+            </div>
+        </fieldset>
+    </form>
+</div>

--- a/test/kioo/om_test.cljs
+++ b/test/kioo/om_test.cljs
@@ -200,3 +200,10 @@
          (testing "nested has selector"
                   (is (= (render-dom (nested-has-template))
                          "<div class=\"form-group\" id=\"test\"><input name=\"name\" type=\"text\"></div>"))))
+
+;; kioo-generated component takes a long time to appear in the page when using reagent but not Om
+(deftemplate minform "min-form.html" [])
+
+(deftest form-timing-test
+         (testing "Om-Kioo doesn't suffer from slow construction of React nodes in Safari/Phantom"
+                  (is (= (render-dom minform) ""))))

--- a/test/kioo/reagent_test.cljs
+++ b/test/kioo/reagent_test.cljs
@@ -234,3 +234,11 @@
          (testing "nested has selector"
                   (is (= (render-dom nested-has-template)
                          "<div class=\"form-group\" id=\"test\"><input name=\"name\" type=\"text\"></div>"))))
+
+;; problematic kioo-generated component takes a long time to appear in the page
+(deftemplate minform "min-form.html" [])
+
+(deftest form-timing-test
+         (testing "time needed to parse form"
+                  (is (= (render-dom minform)
+                         "<div class=\"outcomes\">\n    <h2>Outcomes</h2>\n    <form>\n        <fieldset>\n            <legend>Outcomes assessment</legend>\n            <div>\n                <div>\n                    <label for=\"test\">Test label</label>\n                    <input id=\"test\" type=\"date\">\n                </div>\n            </div>\n        </fieldset>\n    </form>\n</div>"))))

--- a/test/kioo/reagent_test.cljs
+++ b/test/kioo/reagent_test.cljs
@@ -235,10 +235,9 @@
                   (is (= (render-dom nested-has-template)
                          "<div class=\"form-group\" id=\"test\"><input name=\"name\" type=\"text\"></div>"))))
 
-;; problematic kioo-generated component takes a long time to appear in the page
 (deftemplate minform "min-form.html" [])
-
-(deftest form-timing-test
-         (testing "time needed to parse form"
-                  (is (= (render-dom minform)
-                         "<div class=\"outcomes\">\n    <h2>Outcomes</h2>\n    <form>\n        <fieldset>\n            <legend>Outcomes assessment</legend>\n            <div>\n                <div>\n                    <label for=\"test\">Test label</label>\n                    <input id=\"test\" type=\"date\">\n                </div>\n            </div>\n        </fieldset>\n    </form>\n</div>"))))
+;; uncomment following test to experience Reagent-Kioo issue
+;; commented-out here as it makes Phantom.js eventually fall over after hogging CPU, which is no fun
+#_(deftest form-timing-test
+         (testing "Reagent-Kioo suffers from slow construction of React nodes in Safari/Phantom"
+                  (is (= (render-dom minform) ""))))


### PR DESCRIPTION
I added a sample html file and identical tests to the Om and reagent test files to show how the issue applies only when using Kioo with Reagent.

I commented out the reagent test as it causes Phantom.js to fall over rather than crash gracefully or quickly, which can be pretty annoying when continuously testing.