### PR TITLE
Added a :process-ast option to modify templates at compile time.

### DIFF
--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -112,9 +112,13 @@
 
 (defn parse-html
   "parses html with a pre-processing step provided by resource-fn
-   returns an enlive compatible data structure."
-  [path resource-fn]
-  (html-resource (resource-fn path)))
+  returns an enlive compatible data structure. If provided, ast-fn
+  is applied to the parsed data structure."
+  ([path resource-fn]
+   (html-resource (resource-fn path)))
+  ([path resource-fn ast-fn]
+   (let [ast-fn (or ast-fn identity)]
+     (ast-fn (parse-html path resource-fn)))))
 
 (defn component*
   "this is the generic component that takes emitter
@@ -125,7 +129,8 @@
   ([path sel trans emit-opts]
      (let [path-obj (eval path)
            resource-fn (resolve-resource-fn path-obj emit-opts)
-           root (parse-html path-obj resource-fn)
+           ast-fn (:process-ast emit-opts)
+           root (parse-html path-obj resource-fn ast-fn)
            start (if (= :root sel)
                     root
                     (select root (eval-selector sel)))


### PR DESCRIPTION
The :process-ast option expects a function that transforms the
enlive-style template, right after parsing from HTML. This allows the
programmer to inject arbitrary ClojureScript into the template before
applying transforms and passing it to the emitter functions. The
injection happens at compile time, but the transformation function can
inject clojurescript code that will run at runtime.

One use case for this is embedding a minilanguage into text nodes in the
HTML templates: the transformation function in this case traverses the
template, parsing string nodes and replacing them with suitable
clojurescript function calls.

This is in response to issue #64 (Compile Time Transforms), and should be enough to solve my problem.