### PR TITLE
Compile time transforms

### DIFF
--- a/test/kioo/core_test.cljs
+++ b/test/kioo/core_test.cljs
@@ -23,8 +23,12 @@
       (is (= "<div id=\"tmp\">success</div>" (render-dom comp)))))
   (testing "compile-time content replace"
     (let [comp (component "simple-div.html"
-                          {[:div] {(kioo.common/content "success") (wrap :section)}})]
+                          {[:div] {(kioo.common/content "success") (wrap :section {})}})]
       (is (= "<section><div id=\"tmp\">success</div></section>" (render-dom comp)))))
+  (testing "compile-time empty content sugar"
+    (let [comp (component "simple-div.html"
+                          {[:div] [wrap :section {}]})]
+      (is (= "<section><div id=\"tmp\"></div></section>" (render-dom comp)))))
   (testing "first-of-type naked symbol"
     (let [comp (component "list.html" [:ul [:li first-of-type]] {})]
       (is (= "<li>1</li>" (render-dom comp)))))

--- a/test/kioo/core_test.cljs
+++ b/test/kioo/core_test.cljs
@@ -21,6 +21,10 @@
     (let [comp (component "simple-div.html"
                           {[:div] (content "success")})]
       (is (= "<div id=\"tmp\">success</div>" (render-dom comp)))))
+  (testing "compile-time content replace"
+    (let [comp (component "simple-div.html"
+                          {[:div] {(kioo.common/content "success") (wrap :section)}})]
+      (is (= "<section><div id=\"tmp\">success</div></section>" (render-dom comp)))))
   (testing "first-of-type naked symbol"
     (let [comp (component "list.html" [:ul [:li first-of-type]] {})]
       (is (= "<li>1</li>" (render-dom comp)))))


### PR DESCRIPTION
This allows having transforms that should be performed during compile-time. Main reason for this were that when you have components that are containers for other components you have great level of markup duplication when you'll never actually need it. Think of page with container with list of files. list container will contain all markup with sample files, it's container also will contain it, and page layout container will also contain it. With this changes you may have it like this:
```clojure
(defsnippet file-component' "templates/profile.html" [:section.profile-main-section :#tab-files [:.col-xs-3.file-outer first-of-type]]
 [file local-state owner folder stats]
 {[:.file-content-type] {(kioo.common/content)
                         (kioo/substitute [category-label/category-label-component file])}
```
Above will apply `(kioo.common/content)` at compile-time, so resulting clojurescript for the component won't contain markup that would always be replaced by `(kioo/substitute [category-label/category-label-component file])` at runtime.

`(kioo.common/content)` is the most immediatelly useful compile-time transform, so I've also added shorthand syntax for it (notice square brackets):

```clojure
(defsnippet file-component' "templates/profile.html" [:section.profile-main-section :#tab-files [:.col-xs-3.file-outer first-of-type]]
[file local-state owner folder stats]
{[:.file-content-type] [kioo/substitute [category-label/category-label-component file]]
```
This does exactly the same thing as above, but arguably much cleaner.