### PR TITLE
Fix for "React-16: Supported Version"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 /classes
 /checkouts
+/node_modules
 pom.xml
 pom.xml.asc
 *.jar
@@ -14,3 +15,4 @@ pom.xml.asc
 *.*~
 .idea/
 *.iml
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -324,7 +324,11 @@ Not supported yet
 (move)
 ```
 
+## Running The Tests
 
+The server side tests can be run by `lein auto-test-clj` .
+
+To test the ClojureScript side you need to have [PhantomJS](http://phantomjs.org/) installed. Then you can invoke `lein auto-test-cljs` to run the tests.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Not supported yet
 
 The server side tests can be run by `lein auto-test-clj` .
 
-To test the ClojureScript side you need to have [PhantomJS](http://phantomjs.org/) installed. Then you can invoke `lein auto-test-cljs` to run the tests.
+To test the ClojureScript side you need to have [Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome) installed. Then you can invoke `lein auto-test-cljs` to run the tests.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,9 @@ Not supported yet
 
 The server side tests can be run by `lein auto-test-clj` .
 
-To test the ClojureScript side you need to have [Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome) installed. Then you can invoke `lein auto-test-cljs` to run the tests.
+To test the ClojureScript side you need to have [Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome) installed.
+
+Then you can invoke `lein with-profile +react-15 auto-test-cljs` to run the tests with React v15 or `lein with-profile +react-16 auto-test-cljs` with React v16 respectively.
 
 ## Thanks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -451,10 +451,11 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
+        "create-react-class": "15.6.3",
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
@@ -462,9 +463,9 @@
       }
     },
     "react-dom": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
-      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,622 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@cljs-oss/module-deps": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@cljs-oss/module-deps/-/module-deps-1.1.1.tgz",
+      "integrity": "sha1-YmZ/KCFk8/EParnxJLpBb9EkOfo=",
+      "requires": {
+        "JSONStream": "1.3.2",
+        "babel-traverse": "6.26.0",
+        "babylon": "6.18.0",
+        "browser-resolve": "1.11.2",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "defined": "1.0.0",
+        "detective": "4.7.1",
+        "duplexer2": "0.1.4",
+        "enhanced-resolve": "3.4.1",
+        "inherits": "2.0.3",
+        "konan": "1.1.0",
+        "parents": "1.0.1",
+        "readable-stream": "2.3.6",
+        "resolve": "1.7.1",
+        "stream-combiner2": "1.1.1",
+        "subarg": "1.0.0",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
+    "acorn": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.5",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "browser-resolve": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+        }
+      }
+    },
+    "cached-path-relative": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "concat-stream": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        }
+      }
+    },
+    "core-js": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-react-class": {
+      "version": "15.6.3",
+      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "detective": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "requires": {
+        "acorn": "5.5.3",
+        "defined": "1.0.0"
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "2.3.6"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.21"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
+      }
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "requires": {
+        "prr": "1.0.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
+    "konan": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/konan/-/konan-1.1.0.tgz",
+      "integrity": "sha1-M3dDxLl7S9Hvi2KiSzFeuLxLIJQ=",
+      "requires": {
+        "babel-traverse": "6.26.0",
+        "babylon": "6.18.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "requires": {
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "requires": {
+        "path-platform": "0.11.15"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
+      }
+    },
+    "react-dom": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
+      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
+      }
+    },
+    "react-dom-factories": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.2.tgz",
+      "integrity": "sha1-63cFxNs2+1AbOqOP91lhaqD/luA="
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        }
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "resolve": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "requires": {
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+      "requires": {
+        "minimist": "1.2.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "tapable": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
+      }
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "@cljs-oss/module-deps": "^1.1.1",
     "create-react-class": "^15.6.3",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
+    "react": "^15.6.2",
+    "react-dom": "^15.6.2",
     "react-dom-factories": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "@cljs-oss/module-deps": "^1.1.1",
+    "create-react-class": "^15.6.3",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
+    "react-dom-factories": "^1.0.2"
+  }
+}

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :min-lein-version "2.0.0"
   :lein-release {:deploy-via :clojars}
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[enlive "1.1.5"]
                  [cljsjs/react-dom "15.4.0-0"]
                  [cljsjs/react-dom-server "15.4.0-0"]
@@ -16,30 +16,30 @@
                  [hickory "0.7.1"]
                  [org.omcljs/om "0.9.0" :exclusions [cljsjs/react]]
                  [reagent "0.6.1" :exclusions [cljsjs/react]]
-                 [enlive-ws  "0.1.1"]]
-  :plugins [[lein-cljsbuild "1.1.0"]
-            [lein-doo "0.1.6"]
-            [lein-shell "0.4.0"]
-            [lein-ancient "0.5.4"]
-            [lein-marginalia "0.8.0"]]
-  :aliases
-  {"auto-test"
-   ["do" "clean"
-    ["doo" "phantom" "test"]]}
+                 [enlive-ws "0.1.1"]]
+  :profiles {:dev {:plugins [[lein-cljsbuild "1.1.7"]
+                             [lein-doo "0.1.10"]
+                             [lein-shell "0.5.0"]
+                             [lein-ancient "0.6.15"]
+                             [lein-marginalia "0.9.1"]
+                             [com.jakemccrary/lein-test-refresh "0.22.0"]]}}
 
-  :cljsbuild {:builds [{:id "dev"
+  :aliases {"auto-test-clj"  ["test-refresh"]
+            "auto-test-cljs" ["do" "clean"
+                              ["doo" "phantom" "test"]]}
+
+  :cljsbuild {:builds [{:id           "dev"
+                        :source-paths ["src"]
+                        :compiler     {:output-to     "target/dev/kioo.js"
+                                       :optimizations :none
+                                       :pretty-print  true
+                                       :source-map    true}}
+                       {:id           "test"
                         :source-paths ["src" "test"]
-                        :compiler {:output-to "target/dev/kioo.js"
-                                   :optimizations :none
-                                   :pretty-print true
-                                   :source-map true}}
-                       {:id "test"
-                        :source-paths ["src" "test"]
-                        :compiler {:output-to "target/test/kioo.js"
-                                   :optimizations :none
-                                   :main kioo.test-runner
-                                   :pretty-print true
-                                   }}]}
+                        :compiler     {:output-to     "target/test/kioo.js"
+                                       :optimizations :none
+                                       :main          kioo.test-runner
+                                       :pretty-print  true}}]}
   :resource-paths ["test-resources"]
   :source-paths ["src"]
   :test-paths ["test"])

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
-                 [org.clojure/clojurescript "1.10.238" :scope "provided"]
+                 [org.clojure/clojurescript "1.9.946" :scope "provided"]
                  [org.omcljs/om "1.0.0-beta2" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server] :scope "provided"]
                  [reagent "0.8.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server] :scope "provided"]
                  [com.googlecode.htmlcompressor/htmlcompressor "1.5.2"]

--- a/project.clj
+++ b/project.clj
@@ -58,6 +58,8 @@
             "auto-test-cljs" ["do" "clean"
                               ["doo" "chrome-headless" "test"]]}
 
+  :clean-targets ^{:protect false} ["target" "out"] ;; adding "out" as a clean target makes switching between react-15 and react-16 easier
+
   :resource-paths ["test-resources"]
   :source-paths ["src"]
   :test-paths ["test"])

--- a/project.clj
+++ b/project.clj
@@ -24,9 +24,9 @@
                              [lein-marginalia "0.9.1"]
                              [com.jakemccrary/lein-test-refresh "0.22.0"]]}}
 
-  :aliases {"auto-test-clj"  ["test-refresh"]
+  :aliases {"auto-test-clj" ["test-refresh"]
             "auto-test-cljs" ["do" "clean"
-                              ["doo" "phantom" "test"]]}
+                              ["doo" "chrome-headless" "test"]]}
 
   :cljsbuild {:builds [{:id           "dev"
                         :source-paths ["src"]

--- a/project.clj
+++ b/project.clj
@@ -24,9 +24,11 @@
              :react-15 {:dependencies [[cljsjs/react "15.6.2-0"]
                                        [cljsjs/react-dom "15.6.2-0"]
                                        [cljsjs/create-react-class "15.6.2-0"]]
+                        :doo {:paths {:karma "karma --port=9881"}}
                         :cljsbuild {:builds [{:id "test"
                                               :source-paths ["src" "test"]
-                                              :compiler {:output-to "target/test/kioo.js"
+                                              :compiler {:output-to "target/react-15/kioo.js"
+                                                         :output-dir "target/react-15/out"
                                                          :optimizations :none
                                                          :main kioo.test-runner
                                                          :pretty-print true
@@ -39,9 +41,11 @@
              :react-16 {:dependencies [[cljsjs/react "16.3.2-0"]
                                        [cljsjs/react-dom "16.3.2-0"]
                                        [cljsjs/create-react-class "15.6.2-0"]]
+                        :doo {:paths {:karma "karma --port=9882"}}
                         :cljsbuild {:builds [{:id "test"
                                               :source-paths ["src" "test"]
-                                              :compiler {:output-to "target/test/kioo.js"
+                                              :compiler {:output-to "target/react-16/kioo.js"
+                                                         :output-dir "target/react-16/out"
                                                          :optimizations :none
                                                          :main kioo.test-runner
                                                          :pretty-print true
@@ -52,13 +56,10 @@
                                                                     :create-react-class "~15.6.2"
                                                                     :react-dom-factories "~1.0.2"}}}]}}}
 
-  :cljsbuild {:builds []} ;; necessary for projects using kioo as a "checkout" dependency
+  :cljsbuild {:builds []}                                   ;; necessary for projects using kioo as a "checkout" dependency
 
   :aliases {"auto-test-clj" ["test-refresh"]
-            "auto-test-cljs" ["do" "clean"
-                              ["doo" "chrome-headless" "test"]]}
-
-  :clean-targets ^{:protect false} ["target" "out"] ;; adding "out" as a clean target makes switching between react-15 and react-16 easier
+            "auto-test-cljs" ["doo" "chrome-headless" "test"]}
 
   :resource-paths ["test-resources"]
   :source-paths ["src"]

--- a/project.clj
+++ b/project.clj
@@ -5,17 +5,17 @@
   :min-lein-version "2.0.0"
   :lein-release {:deploy-via :clojars}
   :license {:name "Eclipse Public License"
-            :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[enlive "1.1.5"]
-                 [cljsjs/react-dom "15.4.0-0"]
-                 [cljsjs/react-dom-server "15.4.0-0"]
-                 [org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.8.51"]
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[enlive "1.1.6" :exclusions [org.jsoup/jsoup]]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojurescript "1.10.238"]
+                 [cljsjs/react-dom "16.3.2-0"]
+                 [cljsjs/create-react-class "15.6.2-0"]
                  [com.googlecode.htmlcompressor/htmlcompressor "1.5.2"]
-                 [sablono "0.8.0"]
+                 [sablono "0.8.4" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server org.omcljs/om]]
                  [hickory "0.7.1"]
-                 [org.omcljs/om "0.9.0" :exclusions [cljsjs/react]]
-                 [reagent "0.6.1" :exclusions [cljsjs/react]]
+                 [org.omcljs/om "1.0.0-beta2" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server]]
+                 [reagent "0.8.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server]]
                  [enlive-ws "0.1.1"]]
   :profiles {:dev {:plugins [[lein-cljsbuild "1.1.7"]
                              [lein-doo "0.1.10"]
@@ -28,18 +28,30 @@
             "auto-test-cljs" ["do" "clean"
                               ["doo" "chrome-headless" "test"]]}
 
-  :cljsbuild {:builds [{:id           "dev"
+  :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src"]
-                        :compiler     {:output-to     "target/dev/kioo.js"
-                                       :optimizations :none
-                                       :pretty-print  true
-                                       :source-map    true}}
-                       {:id           "test"
+                        :compiler {:output-to "target/dev/kioo.js"
+                                   :optimizations :none
+                                   :pretty-print true
+                                   :source-map true
+                                   :infer-externs true
+                                   :install-deps true
+                                   :npm-deps {:react "~16.3.2"
+                                              :react-dom "~16.3.2"
+                                              :react-dom-factories "~1.0.2"
+                                              :create-react-class "~15.6.2"}}}
+                       {:id "test"
                         :source-paths ["src" "test"]
-                        :compiler     {:output-to     "target/test/kioo.js"
-                                       :optimizations :none
-                                       :main          kioo.test-runner
-                                       :pretty-print  true}}]}
+                        :compiler {:output-to "target/test/kioo.js"
+                                   :optimizations :none
+                                   :main kioo.test-runner
+                                   :pretty-print true
+                                   :infer-externs true
+                                   :install-deps true
+                                   :npm-deps {:react "~16.3.2"
+                                              :react-dom "~16.3.2"
+                                              :react-dom-factories "~1.0.2"
+                                              :create-react-class "~15.6.2"}}}]}
   :resource-paths ["test-resources"]
   :source-paths ["src"]
   :test-paths ["test"])

--- a/project.clj
+++ b/project.clj
@@ -21,9 +21,9 @@
                              [lein-ancient "0.6.15"]
                              [lein-marginalia "0.9.1"]
                              [com.jakemccrary/lein-test-refresh "0.22.0"]]}
-             :react-15 {:dependencies [[cljsjs/react "15.6.2-0" :scope "provided"]
-                                       [cljsjs/react-dom "15.6.2-0" :scope "provided"]
-                                       [cljsjs/create-react-class "15.6.2-0" :scope "provided"]]
+             :react-15 {:dependencies [[cljsjs/react "15.6.2-0"]
+                                       [cljsjs/react-dom "15.6.2-0"]
+                                       [cljsjs/create-react-class "15.6.2-0"]]
                         :cljsbuild {:builds [{:id "test"
                                               :source-paths ["src" "test"]
                                               :compiler {:output-to "target/test/kioo.js"
@@ -36,9 +36,9 @@
                                                                     :react-dom "~15.6.2"
                                                                     :create-react-class "~15.6.2"
                                                                     :react-dom-factories "~1.0.2"}}}]}}
-             :react-16 {:dependencies [[cljsjs/react "16.3.2-0" :scope "provided"]
-                                       [cljsjs/react-dom "16.3.2-0" :scope "provided"]
-                                       [cljsjs/create-react-class "15.6.2-0" :scope "provided"]]
+             :react-16 {:dependencies [[cljsjs/react "16.3.2-0"]
+                                       [cljsjs/react-dom "16.3.2-0"]
+                                       [cljsjs/create-react-class "15.6.2-0"]]
                         :cljsbuild {:builds [{:id "test"
                                               :source-paths ["src" "test"]
                                               :compiler {:output-to "target/test/kioo.js"

--- a/project.clj
+++ b/project.clj
@@ -6,52 +6,58 @@
   :lein-release {:deploy-via :clojars}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[enlive "1.1.6" :exclusions [org.jsoup/jsoup]]
-                 [org.clojure/clojure "1.9.0"]
-                 [org.clojure/clojurescript "1.10.238"]
-                 [cljsjs/react-dom "16.3.2-0"]
-                 [cljsjs/create-react-class "15.6.2-0"]
+  :dependencies [[org.clojure/clojure "1.9.0" :scope "provided"]
+                 [org.clojure/clojurescript "1.10.238" :scope "provided"]
+                 [org.omcljs/om "1.0.0-beta2" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server] :scope "provided"]
+                 [reagent "0.8.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server] :scope "provided"]
                  [com.googlecode.htmlcompressor/htmlcompressor "1.5.2"]
-                 [sablono "0.8.4" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server org.omcljs/om]]
+                 [sablono "0.8.4" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server]]
                  [hickory "0.7.1"]
-                 [org.omcljs/om "1.0.0-beta2" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server]]
-                 [reagent "0.8.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server]]
+                 [enlive "1.1.6" :exclusions [org.jsoup/jsoup]]
                  [enlive-ws "0.1.1"]]
   :profiles {:dev {:plugins [[lein-cljsbuild "1.1.7"]
                              [lein-doo "0.1.10"]
                              [lein-shell "0.5.0"]
                              [lein-ancient "0.6.15"]
                              [lein-marginalia "0.9.1"]
-                             [com.jakemccrary/lein-test-refresh "0.22.0"]]}}
+                             [com.jakemccrary/lein-test-refresh "0.22.0"]]}
+             :react-15 {:dependencies [[cljsjs/react "15.6.2-0" :scope "provided"]
+                                       [cljsjs/react-dom "15.6.2-0" :scope "provided"]
+                                       [cljsjs/create-react-class "15.6.2-0" :scope "provided"]]
+                        :cljsbuild {:builds [{:id "test"
+                                              :source-paths ["src" "test"]
+                                              :compiler {:output-to "target/test/kioo.js"
+                                                         :optimizations :none
+                                                         :main kioo.test-runner
+                                                         :pretty-print true
+                                                         :infer-externs true
+                                                         :install-deps true
+                                                         :npm-deps {:react "~15.6.2"
+                                                                    :react-dom "~15.6.2"
+                                                                    :create-react-class "~15.6.2"
+                                                                    :react-dom-factories "~1.0.2"}}}]}}
+             :react-16 {:dependencies [[cljsjs/react "16.3.2-0" :scope "provided"]
+                                       [cljsjs/react-dom "16.3.2-0" :scope "provided"]
+                                       [cljsjs/create-react-class "15.6.2-0" :scope "provided"]]
+                        :cljsbuild {:builds [{:id "test"
+                                              :source-paths ["src" "test"]
+                                              :compiler {:output-to "target/test/kioo.js"
+                                                         :optimizations :none
+                                                         :main kioo.test-runner
+                                                         :pretty-print true
+                                                         :infer-externs true
+                                                         :install-deps true
+                                                         :npm-deps {:react "~16.3.2"
+                                                                    :react-dom "~16.3.2"
+                                                                    :create-react-class "~15.6.2"
+                                                                    :react-dom-factories "~1.0.2"}}}]}}}
+
+  :cljsbuild {:builds []} ;; necessary for projects using kioo as a "checkout" dependency
 
   :aliases {"auto-test-clj" ["test-refresh"]
             "auto-test-cljs" ["do" "clean"
                               ["doo" "chrome-headless" "test"]]}
 
-  :cljsbuild {:builds [{:id "dev"
-                        :source-paths ["src"]
-                        :compiler {:output-to "target/dev/kioo.js"
-                                   :optimizations :none
-                                   :pretty-print true
-                                   :source-map true
-                                   :infer-externs true
-                                   :install-deps true
-                                   :npm-deps {:react "~16.3.2"
-                                              :react-dom "~16.3.2"
-                                              :react-dom-factories "~1.0.2"
-                                              :create-react-class "~15.6.2"}}}
-                       {:id "test"
-                        :source-paths ["src" "test"]
-                        :compiler {:output-to "target/test/kioo.js"
-                                   :optimizations :none
-                                   :main kioo.test-runner
-                                   :pretty-print true
-                                   :infer-externs true
-                                   :install-deps true
-                                   :npm-deps {:react "~16.3.2"
-                                              :react-dom "~16.3.2"
-                                              :react-dom-factories "~1.0.2"
-                                              :create-react-class "~15.6.2"}}}]}
   :resource-paths ["test-resources"]
   :source-paths ["src"]
   :test-paths ["test"])

--- a/src/kioo/core.clj
+++ b/src/kioo/core.clj
@@ -1,13 +1,10 @@
 (ns kioo.core
   (:refer-clojure :exclude [compile])
   (:require
-   [kioo.util :refer [convert-attrs flatten-nodes]]
-   [net.cgrand.enlive-html :refer [at html-resource select
-                                   any-node pred]]
-   [clojure.string :as string]
-   [kioo.html-parser :as parser]
-   [hickory.core :as hickory]
-   [clojure.java.io :as io]))
+    [kioo.util :refer [convert-attrs flatten-nodes]]
+    [net.cgrand.enlive-html :refer [at html-resource select
+                                    any-node pred]]
+    [kioo.html-parser :as parser]))
 
 (declare compile component*)
 
@@ -17,16 +14,15 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn get-react-sym [tag]
-  (symbol "js" (str "React.DOM." (name tag))))
-
+  (symbol "react-dom-factories" (name tag)))
 
 (defn emit-trans [node children]
   `((kioo.core/handle-wrapper kioo.core/make-dom)
-    (~(:trans node) ~(-> node
-                         (dissoc :trans)
-                         (assoc :attrs (convert-attrs (:attrs node))
-                                :content children
-                                :sym (get-react-sym (:tag node)))))))
+     (~(:trans node) ~(-> node
+                          (dissoc :trans)
+                          (assoc :attrs (convert-attrs (:attrs node))
+                                 :content children
+                                 :sym (get-react-sym (:tag node)))))))
 
 (defn emit-node [node children]
   `(apply ~(get-react-sym (:tag node))
@@ -50,11 +46,11 @@
 (defmacro component
   "React base component definition"
   ([path trans]
-     (component* path trans react-emit-opts))
+   (component* path trans react-emit-opts))
   ([path sel trans]
-     (component* path sel trans react-emit-opts))
+   (component* path sel trans react-emit-opts))
   ([path sel trans opts]
-     (component* path sel trans (merge react-emit-opts (eval opts)))))
+   (component* path sel trans (merge react-emit-opts (eval opts)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Kioo Selector Registry
@@ -85,9 +81,9 @@
   (fn [node]
     (if (:trans node)
       (assoc node :trans `(fn [node#]
-                           (cljs.core/-> node#
-                               (~(:trans node))
-                               (~trans))))
+                            (cljs.core/-> node#
+                                          (~(:trans node))
+                                          (~trans))))
       (assoc node :trans trans))))
 
 
@@ -100,18 +96,18 @@
   (reduce
     (fn [sel-acc sel-frag]
       (conj sel-acc
-          (cond
-           (list? sel-frag) (apply (resolve-sel-var (first sel-frag)) (eval-selector (rest sel-frag)))
-           (or (vector? sel-frag)
-               (map? sel-frag)
-               (set? sel-frag)) (eval-selector sel-frag)
-           (symbol? sel-frag) (resolve-sel-var sel-frag)
-            :else sel-frag)))
-   (cond
-    (vector? sel) []
-    (set? sel) #{}
-    (map? sel) {}
-    :else []) sel))
+            (cond
+              (list? sel-frag) (apply (resolve-sel-var (first sel-frag)) (eval-selector (rest sel-frag)))
+              (or (vector? sel-frag)
+                  (map? sel-frag)
+                  (set? sel-frag)) (eval-selector sel-frag)
+              (symbol? sel-frag) (resolve-sel-var sel-frag)
+              :else sel-frag)))
+    (cond
+      (vector? sel) []
+      (set? sel) #{}
+      (map? sel) {}
+      :else []) sel))
 
 (defn map-trans [node trans-lst]
   (reduce (fn [node [sel trans]]
@@ -122,10 +118,10 @@
 
 (defn resolve-resource-fn [resource {wrapper :resource-wrapper}]
   (cond
-   (not (string? resource)) identity
-   (keyword? wrapper) (resource-wrapper-fns wrapper)
-   (symbol? wrapper) (resolve wrapper)
-   :else parser/->MiniHtml))
+    (not (string? resource)) identity
+    (keyword? wrapper) (resource-wrapper-fns wrapper)
+    (symbol? wrapper) (resolve wrapper)
+    :else parser/->MiniHtml))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Main Structure of Compiler
@@ -147,36 +143,36 @@
    options that define how the component is mapped
    to the underlying library (react, om, reagent)"
   ([path trans emit-opts]
-     (component* path [:body :> any-node] trans emit-opts))
+   (component* path [:body :> any-node] trans emit-opts))
   ([path sel trans emit-opts]
-     (let [path-obj (eval path)
-           resource-fn (resolve-resource-fn path-obj emit-opts)
-           ast-fn (:process-ast emit-opts)
-           root (parse-html path-obj resource-fn ast-fn)
-           start (if (= :root sel)
-                    root
-                    (select root (eval-selector sel)))
-           child-sym (gensym "ch")]
-        (assert (or (empty? trans) (map? trans))
-                "Transforms must be a map - Kioo only supports order independent transforms")
-        (doseq [trans-selector (keys trans)]
-          (if (empty? (select start (eval-selector trans-selector)))
-            (let [message (format "WARNING: File %s does not contain selector %s %s."
-                                  path sel trans-selector)]
-              (try
-                (throw (AssertionError. message))
-                (catch AssertionError e
-                  (binding [*out* *err*]
-                    (println message)))))))
+   (let [path-obj (eval path)
+         resource-fn (resolve-resource-fn path-obj emit-opts)
+         ast-fn (:process-ast emit-opts)
+         root (parse-html path-obj resource-fn ast-fn)
+         start (if (= :root sel)
+                 root
+                 (select root (eval-selector sel)))
+         child-sym (gensym "ch")]
+     (assert (or (empty? trans) (map? trans))
+             "Transforms must be a map - Kioo only supports order independent transforms")
+     (doseq [trans-selector (keys trans)]
+       (if (empty? (select start (eval-selector trans-selector)))
+         (let [message (format "WARNING: File %s does not contain selector %s %s."
+                               path sel trans-selector)]
+           (try
+             (throw (AssertionError. message))
+             (catch AssertionError e
+               (binding [*out* *err*]
+                 (println message)))))))
 
-        `(let [~child-sym ~(compile (map-trans start trans) emit-opts)]
-           (if (= 1 (count ~child-sym))
-             (first ~child-sym)
-             ~((:wrap-fragment emit-opts) :span child-sym))))))
+     `(let [~child-sym ~(compile (map-trans start trans) emit-opts)]
+        (if (= 1 (count ~child-sym))
+          (first ~child-sym)
+          ~((:wrap-fragment emit-opts) :span child-sym))))))
 
 
 (defn compile-node
-  "Emits the compiled sturcure for a single node & its children"
+  "Emits the compiled structure for a single node & its children"
   [node emit-opts]
   (when (:tag node)
     (let [children (compile (:content node) emit-opts)
@@ -192,11 +188,11 @@
   (let [nodes (if (map? node) [node] node)
         cnodes (vec (filter identity
                             (map #(cond
-                                   (map? %) (compile-node % emit-opts)
-                                   (string? %) (if (:emit-str emit-opts)
-                                                 ((:emit-str emit-opts) %)
-                                                 %)
-                                   :else %)
+                                    (map? %) (compile-node % emit-opts)
+                                    (string? %) (if (:emit-str emit-opts)
+                                                  ((:emit-str emit-opts) %)
+                                                  %)
+                                    :else %)
                                  nodes)))]
     `(kioo.util/flatten-nodes ~cnodes)))
 
@@ -211,46 +207,46 @@
 
 (defn snippet*
   ([path sel trans args emit-opts]
-     (snippet* path sel trans args emit-opts false))
+   (snippet* path sel trans args emit-opts false))
   ([path sel trans args emit-opts check-val?]
-     (if check-val?
-       `(kioo.core/value-component
-         (fn ~args
-           ~(component* path sel trans emit-opts)))
-       `(fn ~args
-          ~(component* path sel trans emit-opts)))))
+   (if check-val?
+     `(kioo.core/value-component
+        (fn ~args
+          ~(component* path sel trans emit-opts)))
+     `(fn ~args
+        ~(component* path sel trans emit-opts)))))
 
 (defmacro snippet
   ([path sel args]
-     (snippet* path sel {} args react-emit-opts true))
+   (snippet* path sel {} args react-emit-opts true))
   ([path sel args trans]
-     (snippet* path sel trans args react-emit-opts true))
+   (snippet* path sel trans args react-emit-opts true))
   ([path sel args trans opts]
-     (snippet* path sel trans args (merge react-emit-opts (eval opts)) true)))
+   (snippet* path sel trans args (merge react-emit-opts (eval opts)) true)))
 
 (defmacro template
   ([path args]
-     (snippet* path [:body :> any-node] {} args react-emit-opts true))
+   (snippet* path [:body :> any-node] {} args react-emit-opts true))
   ([path args trans]
-     (snippet* path [:body :> any-node] trans args react-emit-opts true))
+   (snippet* path [:body :> any-node] trans args react-emit-opts true))
   ([path args trans opts]
-     (snippet* path [:body :> any-node] trans args (merge react-emit-opts (eval opts)) true)))
+   (snippet* path [:body :> any-node] trans args (merge react-emit-opts (eval opts)) true)))
 
 (defmacro defsnippet
   ([sym path sel args]
-     `(def ~sym ~(snippet* path sel {} args react-emit-opts true)))
+   `(def ~sym ~(snippet* path sel {} args react-emit-opts true)))
   ([sym path sel args trans]
-     `(def ~sym ~(snippet* path sel trans args react-emit-opts true)))
+   `(def ~sym ~(snippet* path sel trans args react-emit-opts true)))
   ([sym path sel args trans opts]
-     `(def ~sym ~(snippet* path sel trans args (merge react-emit-opts (eval opts)) true))))
+   `(def ~sym ~(snippet* path sel trans args (merge react-emit-opts (eval opts)) true))))
 
 (defmacro deftemplate
   ([sym path args]
-     `(def ~sym ~(snippet* path [:body :> any-node] {} args react-emit-opts true)))
+   `(def ~sym ~(snippet* path [:body :> any-node] {} args react-emit-opts true)))
   ([sym path args trans]
-     `(def ~sym ~(snippet* path [:body :> any-node] trans args react-emit-opts true)))
+   `(def ~sym ~(snippet* path [:body :> any-node] trans args react-emit-opts true)))
   ([sym path args trans opts]
-     `(def ~sym ~(snippet* path [:body :> any-node] trans args (merge react-emit-opts (eval opts)) true))))
+   `(def ~sym ~(snippet* path [:body :> any-node] trans args (merge react-emit-opts (eval opts)) true))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/kioo/core.cljs
+++ b/src/kioo/core.cljs
@@ -4,7 +4,7 @@
             [hickory.core :as hic :refer [parse-fragment as-hiccup]]
             [sablono.core :as sab :include-macros true]
             [kioo.common :as common]
-            [cljsjs.react :as react]
+            [cljsjs.react]
             [cljsjs.create-react-class]
             [react-dom-factories]))
 

--- a/src/kioo/core.cljs
+++ b/src/kioo/core.cljs
@@ -4,15 +4,13 @@
             [hickory.core :as hic :refer [parse-fragment as-hiccup]]
             [sablono.core :as sab :include-macros true]
             [kioo.common :as common]
-            [react]
-            [react-dom]
-            [create-react-class]
+            [cljsjs.react :as react]
+            [cljsjs.create-react-class]
             [react-dom-factories]))
-
 
 (defn value-component [renderer]
   (let [react-component
-        (create-react-class
+        (js/createReactClass
           #js {:shouldComponentUpdate
                (fn [next-props _]
                  (this-as this
@@ -25,7 +23,7 @@
                      (apply renderer
                             (aget (.-props this) "value")
                             (aget (.-props this) "statics")))))})
-        factory (react/createFactory react-component)]
+        factory (js/React.createFactory react-component)]
     (fn [value & static-args]
       (factory #js {:value value :statics static-args}))))
 

--- a/src/kioo/om.cljs
+++ b/src/kioo/om.cljs
@@ -11,7 +11,6 @@
            (flatten-nodes (:content node)))
     node))
 
-
 (def content core/content)
 (def append core/append)
 (def prepend core/prepend)

--- a/src/kioo/om.cljs
+++ b/src/kioo/om.cljs
@@ -1,14 +1,15 @@
 (ns kioo.om
-  (:require [om.dom :as dom]
-            [kioo.core :as core]
-            [kioo.util :refer [flatten-nodes convert-attrs]]))
+  (:require
+    [kioo.core :as core]
+    [kioo.util :refer [flatten-nodes convert-attrs]]
+    [react-dom-factories]))
 
 (defn make-dom [node & body]
   (if (map? node)
-      (apply (:sym node)
-             (clj->js (:attrs node))
-             (flatten-nodes (:content node)))
-      node))
+    (apply (:sym node)
+           (clj->js (:attrs node))
+           (flatten-nodes (:content node)))
+    node))
 
 
 (def content core/content)
@@ -40,7 +41,7 @@
 (defn wrap [tag attrs]
   (fn [node]
     {:tag tag
-     :sym (aget js/React.DOM (name tag))
+     :sym (aget react-dom-factories (name tag))
      :attrs (convert-attrs attrs)
      :content [(make-dom node)]}))
 

--- a/src/kioo/reagent.cljs
+++ b/src/kioo/reagent.cljs
@@ -1,19 +1,19 @@
 (ns kioo.reagent
   (:require [kioo.core :as core]
-            [kioo.util :as util :refer [flatten-nodes]]
+            [kioo.util :refer [flatten-nodes]]
             [reagent.core :refer [as-component]]))
 
 (defn make-dom [node]
   (let [rnode (if (map? node)
                 (let [c (:content node)]
                   (cond
-                   (vector? c) [(:tag node)
-                                (:attrs node)
-                                (as-component c)]
-                   (seq? c) (reduce #(conj %1 (as-component %2))
-                                    [(:tag node) (:attrs node)]
-                                    c)
-                   :else [(:tag node) (:attrs node) c]))
+                    (vector? c) [(:tag node)
+                                 (:attrs node)
+                                 (as-component c)]
+                    (seq? c) (reduce #(conj %1 (as-component %2))
+                                     [(:tag node) (:attrs node)]
+                                     c)
+                    :else [(:tag node) (:attrs node) c]))
                 node)]
     (as-component rnode)))
 

--- a/src/kioo/reagent.cljs
+++ b/src/kioo/reagent.cljs
@@ -17,7 +17,6 @@
                 node)]
     (as-component rnode)))
 
-
 (def content core/content)
 (def append core/append)
 (def prepend core/prepend)

--- a/src/kioo/util.cljc
+++ b/src/kioo/util.cljc
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [replace])
   (:require
     [clojure.string :refer [split replace capitalize]]
-    #?(:cljs [cljsjs.react :as react])
+    #?(:cljs [cljsjs.react])
     #?(:cljs [cljsjs.create-react-class])))
 
 #?(:cljs (def ^:dynamic *component* nil))

--- a/src/kioo/util.cljc
+++ b/src/kioo/util.cljc
@@ -2,89 +2,86 @@
   (:refer-clojure :exclude [replace])
   (:require
     [clojure.string :refer [split replace capitalize]]
-    #?(:cljs [react])
-    #?(:cljs [react-dom])
-    #?(:cljs [create-react-class])))
+    #?(:cljs [cljsjs.react :as react])
+    #?(:cljs [cljsjs.create-react-class])))
 
-#?(:cljs
-   (do
-     (def ^:dynamic *component* nil)
+#?(:cljs (def ^:dynamic *component* nil))
 
-     (def WrapComponent
-       "Wrapper component used to mix-in lifecycle methods
-       This was modified from a similar setup in quiescent"
-       (react/createFactory
-         (create-react-class
-           #js {:render
-                (fn []
-                  (this-as this
-                    (let [dom-fn (aget (.-props this) "dom-fn")
-                          node (aget (.-props this) "node")]
-                      (dom-fn node))))
-                :getInitialState
-                (fn []
-                  (this-as this
-                    (when-let [f (aget (.-props this) "initState")]
-                      (binding [*component* this]
-                        (f this)))))
-                #_:getDefaultProps
-                #_(fn []
-                    (this-as this
-                      (when-let [f (aget (.-props this) "defaultProps")]
-                        (binding [*component* this]
-                          (f this)))))
-                :shouldComponentUpdate
-                (fn [next-props next-state]
-                  (this-as this
-                    (if-let [f (aget (.-props this) "shouldUpdate")]
-                      (binding [*component* this]
-                        (f this next-props next-state))
-                      (not= (aget (.-props this) "node")
-                            (aget next-props "node")))))
-                :componentWillReceiveProps
-                (fn [next-props]
-                  (this-as this
-                    (when-let [f (or (aget (.-props this) "willReceiveProps")
-                                     (aget (.-props this) "onWillReceiveProps"))]
-                      (binding [*component* this]
-                        (f this next-props)))))
-                :componentWillUpdate
-                (fn [next-props next-state]
-                  (this-as this
-                    (when-let [f (or (aget (.-props this) "willUpdate")
-                                     (aget (.-props this) "onWillUpdate"))]
-                      (binding [*component* this]
-                        (f this next-props next-state)))))
-                :componentDidUpdate
-                (fn [prev-props prev-state]
-                  (this-as this
-                    (when-let [f (or (aget (.-props this) "didUpdate")
-                                     (aget (.-props this) "onUpdate")
-                                     (aget (.-props this) "onRender"))]
-                      (binding [*component* this]
-                        (f this prev-props prev-state)))))
-                :componentWillMount
-                (fn []
-                  (this-as this
-                    (when-let [f (or (aget (.-props this) "willMount")
-                                     (aget (.-props this) "onWillMount"))]
-                      (binding [*component* this]
-                        (f this)))))
-                :componentDidMount
-                (fn []
-                  (this-as this
-                    (when-let [f (or (aget (.-props this) "didMount")
-                                     (aget (.-props this) "onMount")
-                                     (aget (.-props this) "onRender"))]
-                      (binding [*component* this]
-                        (f this)))))
-                :componentWillUnmount
-                (fn []
-                  (this-as this
-                    (when-let [f (or (aget (.-props this) "willUnmount")
-                                     (aget (.-props this) "onUnmount"))]
-                      (binding [*component* this]
-                        (f this)))))})))))
+#?(:cljs (def WrapComponent
+           "Wrapper component used to mix-in lifecycle methods
+           This was modified from a similar setup in quiescent"
+           (js/React.createFactory
+             (js/createReactClass
+               #js {:render
+                    (fn []
+                      (this-as this
+                        (let [dom-fn (aget (.-props this) "dom-fn")
+                              node (aget (.-props this) "node")]
+                          (dom-fn node))))
+                    :getInitialState
+                    (fn []
+                      (this-as this
+                        (when-let [f (aget (.-props this) "initState")]
+                          (binding [*component* this]
+                            (f this)))))
+                    #_:getDefaultProps
+                    #_(fn []
+                        (this-as this
+                          (when-let [f (aget (.-props this) "defaultProps")]
+                            (binding [*component* this]
+                              (f this)))))
+                    :shouldComponentUpdate
+                    (fn [next-props next-state]
+                      (this-as this
+                        (if-let [f (aget (.-props this) "shouldUpdate")]
+                          (binding [*component* this]
+                            (f this next-props next-state))
+                          (not= (aget (.-props this) "node")
+                                (aget next-props "node")))))
+                    :componentWillReceiveProps
+                    (fn [next-props]
+                      (this-as this
+                        (when-let [f (or (aget (.-props this) "willReceiveProps")
+                                         (aget (.-props this) "onWillReceiveProps"))]
+                          (binding [*component* this]
+                            (f this next-props)))))
+                    :componentWillUpdate
+                    (fn [next-props next-state]
+                      (this-as this
+                        (when-let [f (or (aget (.-props this) "willUpdate")
+                                         (aget (.-props this) "onWillUpdate"))]
+                          (binding [*component* this]
+                            (f this next-props next-state)))))
+                    :componentDidUpdate
+                    (fn [prev-props prev-state]
+                      (this-as this
+                        (when-let [f (or (aget (.-props this) "didUpdate")
+                                         (aget (.-props this) "onUpdate")
+                                         (aget (.-props this) "onRender"))]
+                          (binding [*component* this]
+                            (f this prev-props prev-state)))))
+                    :componentWillMount
+                    (fn []
+                      (this-as this
+                        (when-let [f (or (aget (.-props this) "willMount")
+                                         (aget (.-props this) "onWillMount"))]
+                          (binding [*component* this]
+                            (f this)))))
+                    :componentDidMount
+                    (fn []
+                      (this-as this
+                        (when-let [f (or (aget (.-props this) "didMount")
+                                         (aget (.-props this) "onMount")
+                                         (aget (.-props this) "onRender"))]
+                          (binding [*component* this]
+                            (f this)))))
+                    :componentWillUnmount
+                    (fn []
+                      (this-as this
+                        (when-let [f (or (aget (.-props this) "willUnmount")
+                                         (aget (.-props this) "onUnmount"))]
+                          (binding [*component* this]
+                            (f this)))))}))))
 
 (def dont-camel-case #{"aria" "data"})
 

--- a/src/kioo/util.cljc
+++ b/src/kioo/util.cljc
@@ -1,87 +1,90 @@
 (ns kioo.util
   (:refer-clojure :exclude [replace])
-  (:require [clojure.string :refer [split replace capitalize]]
-            #?(:cljs [cljsjs.react])))
+  (:require
+    [clojure.string :refer [split replace capitalize]]
+    #?(:cljs [react])
+    #?(:cljs [react-dom])
+    #?(:cljs [create-react-class])))
 
 #?(:cljs
-    (do
-      (def ^:dynamic *component* nil)
+   (do
+     (def ^:dynamic *component* nil)
 
-      (def WrapComponent
-        "Wrapper component used to mix-in lifecycle methods
-        This was modified from a similar setup in quiescent"
-        (.createFactory js/React
-                        (.createClass js/React
-                                      #js {:render
-                                           (fn []
-                                             (this-as this
-                                                      (let [dom-fn (aget (.-props this) "dom-fn")
-                                                            node (aget (.-props this) "node")]
-                                                        (dom-fn node))))
-                                           :getInitialState
-                                           (fn []
-                                             (this-as this
-                                                      (when-let [f  (aget (.-props this) "initState")]
-                                                        (binding [*component* this]
-                                                          (f this)))))
-                                           #_:getDefaultProps
-                                           #_(fn []
-                                               (this-as this
-                                                        (when-let [f (aget (.-props this) "defaultProps")]
-                                                          (binding [*component* this]
-                                                            (f this)))))
-                                           :shouldComponentUpdate
-                                           (fn [next-props next-state]
-                                             (this-as this
-                                                      (if-let [f (aget (.-props this) "shouldUpdate")]
-                                                        (binding [*component* this]
-                                                          (f this next-props next-state))
-                                                        (not= (aget (.-props this) "node")
-                                                              (aget next-props "node")))))
-                                           :componentWillReceiveProps
-                                           (fn [next-props]
-                                             (this-as this
-                                                      (when-let [f (or (aget (.-props this) "willReceiveProps")
-                                                                       (aget (.-props this) "onWillReceiveProps"))]
-                                                        (binding [*component* this]
-                                                          (f this next-props)))))
-                                           :componentWillUpdate
-                                           (fn [next-props next-state]
-                                             (this-as this
-                                                      (when-let [f (or (aget (.-props this) "willUpdate")
-                                                                       (aget (.-props this) "onWillUpdate"))]
-                                                        (binding [*component* this]
-                                                          (f this next-props next-state)))))
-                                           :componentDidUpdate
-                                           (fn [prev-props prev-state]
-                                             (this-as this
-                                                      (when-let [f (or (aget (.-props this) "didUpdate")
-                                                                       (aget (.-props this) "onUpdate")
-                                                                       (aget (.-props this) "onRender"))]
-                                                        (binding [*component* this]
-                                                          (f this prev-props prev-state)))))
-                                           :componentWillMount
-                                           (fn []
-                                             (this-as this
-                                                      (when-let [f (or (aget (.-props this) "willMount")
-                                                                       (aget (.-props this) "onWillMount"))]
-                                                        (binding [*component* this]
-                                                          (f this)))))
-                                           :componentDidMount
-                                           (fn []
-                                             (this-as this
-                                                      (when-let [f (or (aget (.-props this) "didMount")
-                                                                       (aget (.-props this) "onMount")
-                                                                       (aget (.-props this) "onRender"))]
-                                                        (binding [*component* this]
-                                                          (f this)))))
-                                           :componentWillUnmount
-                                           (fn []
-                                             (this-as this
-                                                      (when-let [f (or (aget (.-props this) "willUnmount")
-                                                                       (aget (.-props this) "onUnmount"))]
-                                                        (binding [*component* this]
-                                                          (f this)))))})))))
+     (def WrapComponent
+       "Wrapper component used to mix-in lifecycle methods
+       This was modified from a similar setup in quiescent"
+       (react/createFactory
+         (create-react-class
+           #js {:render
+                (fn []
+                  (this-as this
+                    (let [dom-fn (aget (.-props this) "dom-fn")
+                          node (aget (.-props this) "node")]
+                      (dom-fn node))))
+                :getInitialState
+                (fn []
+                  (this-as this
+                    (when-let [f (aget (.-props this) "initState")]
+                      (binding [*component* this]
+                        (f this)))))
+                #_:getDefaultProps
+                #_(fn []
+                    (this-as this
+                      (when-let [f (aget (.-props this) "defaultProps")]
+                        (binding [*component* this]
+                          (f this)))))
+                :shouldComponentUpdate
+                (fn [next-props next-state]
+                  (this-as this
+                    (if-let [f (aget (.-props this) "shouldUpdate")]
+                      (binding [*component* this]
+                        (f this next-props next-state))
+                      (not= (aget (.-props this) "node")
+                            (aget next-props "node")))))
+                :componentWillReceiveProps
+                (fn [next-props]
+                  (this-as this
+                    (when-let [f (or (aget (.-props this) "willReceiveProps")
+                                     (aget (.-props this) "onWillReceiveProps"))]
+                      (binding [*component* this]
+                        (f this next-props)))))
+                :componentWillUpdate
+                (fn [next-props next-state]
+                  (this-as this
+                    (when-let [f (or (aget (.-props this) "willUpdate")
+                                     (aget (.-props this) "onWillUpdate"))]
+                      (binding [*component* this]
+                        (f this next-props next-state)))))
+                :componentDidUpdate
+                (fn [prev-props prev-state]
+                  (this-as this
+                    (when-let [f (or (aget (.-props this) "didUpdate")
+                                     (aget (.-props this) "onUpdate")
+                                     (aget (.-props this) "onRender"))]
+                      (binding [*component* this]
+                        (f this prev-props prev-state)))))
+                :componentWillMount
+                (fn []
+                  (this-as this
+                    (when-let [f (or (aget (.-props this) "willMount")
+                                     (aget (.-props this) "onWillMount"))]
+                      (binding [*component* this]
+                        (f this)))))
+                :componentDidMount
+                (fn []
+                  (this-as this
+                    (when-let [f (or (aget (.-props this) "didMount")
+                                     (aget (.-props this) "onMount")
+                                     (aget (.-props this) "onRender"))]
+                      (binding [*component* this]
+                        (f this)))))
+                :componentWillUnmount
+                (fn []
+                  (this-as this
+                    (when-let [f (or (aget (.-props this) "willUnmount")
+                                     (aget (.-props this) "onUnmount"))]
+                      (binding [*component* this]
+                        (f this)))))})))))
 
 (def dont-camel-case #{"aria" "data"})
 
@@ -95,44 +98,44 @@
 
 (def attribute-map
   (assoc
-      (reduce #(assoc %1 (keyword (.toLowerCase (name %2))) %2) {}
-              [:accessKey :allowFullScreen :allowTransparency :autoComplete
-               :autoFocus :autoPlay :cellPadding :cellSpacing :charSet
-               :colSpan :contentEditable :contextMenu :dateTime :encType
-               :formEncType :formNoValidate :frameBorder :httpEquiv :itemProp
-               :itemScope :itemType :maxLength :noValidate :radioGroup :readOnly
-               :rowSpan :scrollLeft :scrollTop :spellCheck :srcDoc :tabIndex
-               :gradientTransform :gradientUnits :spreadMethod :stopColor
-               :stopOpacity :strokeLinecap :strokeWidth :textAnchor :viewBox])
+    (reduce #(assoc %1 (keyword (.toLowerCase (name %2))) %2) {}
+            [:accessKey :allowFullScreen :allowTransparency :autoComplete
+             :autoFocus :autoPlay :cellPadding :cellSpacing :charSet
+             :colSpan :contentEditable :contextMenu :dateTime :encType
+             :formEncType :formNoValidate :frameBorder :httpEquiv :itemProp
+             :itemScope :itemType :maxLength :noValidate :radioGroup :readOnly
+             :rowSpan :scrollLeft :scrollTop :spellCheck :srcDoc :tabIndex
+             :gradientTransform :gradientUnits :spreadMethod :stopColor
+             :stopOpacity :strokeLinecap :strokeWidth :textAnchor :viewBox])
     :accept-charset :acceptCharset
-    :class          :className
-    :for            :htmlFor))
+    :class :className
+    :for :htmlFor))
 
 (defn transform-keys [attrs]
   (reduce (fn [m [k v]]
             (assoc m (or (attribute-map k) k) v)) {} attrs))
 
 (defn convert-attrs [attrs]
-  (let [style  (when (:style attrs)
-                 (let [style (:style attrs)]
-                   (cond
-                     (string? style)
-                     (let [vals (re-seq #"\s*([^:;]*)[:][\s]*([^;]+)"
-                                        style)]
-                       (reduce (fn [m [_ k v]]
-                                 (assoc m
-                                        (camel-case k)
-                                        (.trim v)))
-                               {} vals))
-                     (map? style)
-                     (zipmap (map camel-case (keys style)) (vals style))
-                     :else style)))
+  (let [style (when (:style attrs)
+                (let [style (:style attrs)]
+                  (cond
+                    (string? style)
+                    (let [vals (re-seq #"\s*([^:;]*)[:][\s]*([^;]+)"
+                                       style)]
+                      (reduce (fn [m [_ k v]]
+                                (assoc m
+                                  (camel-case k)
+                                  (.trim v)))
+                              {} vals))
+                    (map? style)
+                    (zipmap (map camel-case (keys style)) (vals style))
+                    :else style)))
         class-name (:class attrs)]
     (cond-> attrs
-      :always
-      (transform-keys)
-      style
-      (assoc :style style))))
+            :always
+            (transform-keys)
+            style
+            (assoc :style style))))
 
 
 (defn flatten-nodes [nodes]

--- a/test/kioo/core_test.clj
+++ b/test/kioo/core_test.clj
@@ -1,14 +1,4 @@
-(ns kioo.core
-  (:require [clojure.test :as test :refer :all]
-            [clojure.java.io :as io]
-            [kioo.core :as core :refer :all]))
-
-(defn path-exists? [p]
-  (.exists (io/file p)))
-
-(deftest path-exists-test
-  (is (path-exists? "simple-div.html"))
-  (is (path-exists? "test-resources/simple-div.html"))
-  (is (not (path-exists? "file-does-not-exist.txt")))
-  (is (path-exists? :not-a-path)))
-
+(ns kioo.core-test
+  (:refer-clojure :exclude [compile])
+  (:require [clojure.test :refer :all]
+            [kioo.core :refer :all]))

--- a/test/kioo/om_test.cljs
+++ b/test/kioo/om_test.cljs
@@ -6,6 +6,7 @@
                              remove-class wrap unwrap set-class
                              html html-content listen set-attr]]
             [kioo.test :refer [render-dom]]
+            [om.dom :as dom]
             [goog.dom :as gdom])
   (:require-macros [kioo.om :refer [component snippet template
                                     defsnippet deftemplate]]

--- a/test/kioo/reagent_test.cljs
+++ b/test/kioo/reagent_test.cljs
@@ -23,8 +23,7 @@
         (util/strip-comments))))
 
 (defn initial-render [comp]
-  (let [comp-fn #(do comp)
-        container (goog.dom/createDom "div")]
+  (let [container (goog.dom/createDom "div")]
     (gdom/append (.-body js/document) container)
     (reagent/render-component [comp] container)
     container))
@@ -58,7 +57,7 @@
     (let [atm (atom "one")
           comp2 #(component "simple-div.html"
                             {[:div] (do-> (remove-attr :id)
-                                          (content @atm))} )
+                                          (content @atm))})
           comp #(component "simple-div.html"
                            {[:div] (content [comp2])})
           container (initial-render comp)
@@ -87,80 +86,80 @@
              html-str2))))
   (testing "prepend test"
     (let [comp #(component "simple-div.html"
-                          {[:div] (prepend "success")})]
+                           {[:div] (prepend "success")})]
       (is (= "<div id=\"tmp\">successtest</div>"
              (render-dom comp)))))
   (testing "set-attr test"
     (let [comp #(component "simple-div.html"
-                          {[:div] (set-attr :id "success")})]
+                           {[:div] (set-attr :id "success")})]
       (is (= "<div id=\"success\">test</div>"
              (render-dom comp)))))
   (testing "remove-attr test"
     (let [comp #(component "simple-div.html"
-                          {[:div] (remove-attr :id)})]
+                           {[:div] (remove-attr :id)})]
       (is (= "<div>test</div>"
              (render-dom comp)))))
   (testing "before test"
     (let [comp #(component "simple-div.html"
-                          {[:div] (before "success")})]
+                           {[:div] (before "success")})]
       (is (= "<span>success<div id=\"tmp\">test</div></span>"
              (render-dom comp)))))
   (testing "after test"
     (let [comp #(component "simple-div.html"
-                          {[:div] (after "success")})]
+                           {[:div] (after "success")})]
       (is (= "<span><div id=\"tmp\">test</div>success</span>"
              (render-dom comp)))))
   (testing "add-class test"
     (let [comp #(component "class-span.html" [:span]
-                          {[:#s] (add-class "suc")})]
+                           {[:#s] (add-class "suc")})]
       (is (= "<span id=\"s\" class=\"cl cls suc\">testing</span>"
              (render-dom comp)))))
   (testing "remove-class test"
     (let [comp #(component "class-span.html" [:span]
-                          {[:#s] (remove-class "cl")})]
+                           {[:#s] (remove-class "cl")})]
       (is (= "<span id=\"s\" class=\" cls\">testing</span>"
              (render-dom comp)))))
   (testing "set-class test"
     (let [comp #(component "class-span.html" [:span]
-                          {[:#s] (set-class "cl")})]
+                           {[:#s] (set-class "cl")})]
       (is (= "<span id=\"s\" class=\" cl\">testing</span>"
              (render-dom comp)))))
   (testing "set-style test"
     (let [comp #(component "style-span.html" [:span]
-                          {[:#s] (set-style :display "none")})]
+                           {[:#s] (set-style :display "none")})]
       (is (= "<span id=\"s\" style=\"color: red; background-color: blue; display: none;\">testing</span>"
              (render-dom comp)))))
   (testing "remove-style test"
     (let [comp #(component "style-span.html" [:span]
-                          {[:#s] (remove-style :color)})]
+                           {[:#s] (remove-style :color)})]
       (is (= "<span id=\"s\" style=\"background-color: blue;\">testing</span>"
              (render-dom comp)))))
   (testing "do-> test"
     (let [comp #(component "style-span.html" [:span]
-                          {[:#s] (do->
-                                  (remove-attr :id)
-                                  (remove-style :color))})]
+                           {[:#s] (do->
+                                    (remove-attr :id)
+                                    (remove-style :color))})]
       (is (= "<span style=\"background-color: blue;\">testing</span>"
              (render-dom comp)))))
   (testing "wrap test"
     (let [comp #(component "wrap-test.html" [:span]
-                          {[:#s] (wrap :div {:id "test"})})]
+                           {[:#s] (wrap :div {:id "test"})})]
       (is (= "<div id=\"test\"><span id=\"s\">testing</span></div>"
              (render-dom comp)))))
   (testing "unwrap test"
     (let [comp #(component "wrap-test.html" [:div]
-                          {[:div] unwrap})]
+                           {[:div] unwrap})]
       (is (= "<span id=\"s\">testing</span>"
              (render-dom comp)))))
   (testing "html test"
     (let [comp #(component "simple-div.html"
-                          {[:div] (content (html [:h1 {:class "t"}
-                                                  [:span "t1"]]))})]
+                           {[:div] (content (html [:h1 {:class "t"}
+                                                   [:span "t1"]]))})]
       (is (= "<div id=\"tmp\"><h1 class=\"t\"><span>t1</span></h1></div>"
              (render-dom comp)))))
   (testing "html-content test"
     (let [comp #(component "simple-div.html"
-                          {[:div] (html-content "<h1>t1</h1><em><span>t2</span></em>")})]
+                           {[:div] (html-content "<h1>t1</h1><em><span>t2</span></em>")})]
       (is (= "<div id=\"tmp\"><h1>t1</h1><em><span>t2</span></em></div>"
              (render-dom comp)))))
   (testing "listen on render"
@@ -171,7 +170,6 @@
                                             #(reset! atm "success"))}))]
       (render-dom comp)
       (is (= "success" @atm)))))
-
 
 (defsnippet snip1 "wrap-test.html" [:span] [] {})
 (deftemplate tmp1 "simple-div.html" [] {})
@@ -213,34 +211,33 @@
     (is (= "<div id=\"tmp\">success</div>"
            (render-dom #(tmp2 "success"))))))
 
-
 (deftest ordering-inside-do->test
   (testing "Testing content, after then before"
     (let [comp #(component "simple-div.html" {[:div]
-                                             (do-> (content "success")
-                                                   (after "after")
-                                                   (before "before"))}) ]
+                                              (do-> (content "success")
+                                                    (after "after")
+                                                    (before "before"))})]
       (is (= "<span>before<div id=\"tmp\">success</div>after</span>"
              (render-dom comp)))))
   (testing "Testing content, before then after"
     (let [comp #(component "simple-div.html" {[:div]
-                                             (do-> (content "success")
-                                                   (before "before")
-                                                   (after "after"))}) ]
+                                              (do-> (content "success")
+                                                    (before "before")
+                                                    (after "after"))})]
       (is (= "<span>before<div id=\"tmp\">success</div>after</span>"
-             (render-dom comp))))) )
+             (render-dom comp))))))
 
 (deftemplate nested-has-template "nested-has.html" []
-             {[[:.form-group (has [[:input (attr= :name "name")]])]] (set-attr :id "test")})
+  {[[:.form-group (has [[:input (attr= :name "name")]])]] (set-attr :id "test")})
 
 (deftest nested-has-test
-         (testing "nested has selector"
-                  (is (= (render-dom nested-has-template)
-                         "<div class=\"form-group\" id=\"test\"><input type=\"text\" name=\"name\"></div>"))))
+  (testing "nested has selector"
+    (is (= (render-dom nested-has-template)
+           "<div class=\"form-group\" id=\"test\"><input type=\"text\" name=\"name\"></div>"))))
 
 (deftemplate minform "min-form.html" [])
 ;; uncomment following test to experience Reagent-Kioo issue
 ;; commented-out here as it makes Phantom.js eventually fall over after hogging CPU, which is no fun
 #_(deftest form-timing-test
-         (testing "Reagent-Kioo suffers from slow construction of React nodes in Safari/Phantom"
-                  (is (= (render-dom minform) ""))))
+    (testing "Reagent-Kioo suffers from slow construction of React nodes in Safari/Phantom"
+      (is (= (render-dom minform) ""))))

--- a/test/kioo/server/core_test.clj
+++ b/test/kioo/server/core_test.clj
@@ -93,19 +93,19 @@
   (testing "set-style test"
     (let [comp (component "style-span.html" [:span]
                           {[:#s] (set-style :display "none")})]
-      (is (= "<span id=\"s\" style=\"display:none;color:red;\">testing</span>"
+      (is (= "<span id=\"s\" style=\"display:none;backgroundColor:blue;color:red;\">testing</span>"
              comp))))
   (testing "remove-style test"
     (let [comp (component "style-span.html" [:span]
                           {[:#s] (remove-style :color)})]
-      (is (= "<span id=\"s\">testing</span>"
+      (is (= "<span id=\"s\" style=\"backgroundColor:blue;\">testing</span>"
              comp))))
   (testing "do-> test"
     (let [comp (component "style-span.html" [:span]
                           {[:#s] (do->
                                   (remove-attr :id)
                                   (remove-style :color))})]
-      (is (= "<span>testing</span>"
+      (is (= "<span style=\"backgroundColor:blue;\">testing</span>"
              comp))))
   (testing "wrap test"
     (let [comp (component "wrap-test.html" [:span]

--- a/test/kioo/test.cljs
+++ b/test/kioo/test.cljs
@@ -1,19 +1,23 @@
 (ns kioo.test
   (:require [kioo.util :refer [strip-attr strip-comments]]
-            [goog.dom :as dom]))
+            [goog.dom :as dom]
+            [react]
+            [react-dom]
+            [create-react-class]
+            [react-dom-factories]))
 
 (defn body []
   (aget (dom/getElementsByTagNameAndClass "body") 0))
 
 (defn render-dom [children]
-  (let [container (goog.dom/createDom "div")
+  (let [container (dom/createDom "div")
         id (gensym)]
     (goog.dom/append (body) container)
     (let [render-fn (fn []
-                      (this-as this (js/React.DOM.div
-                                     (clj->js {:id id}) children)))
-          component (js/React.createFactory (js/React.createClass #js {:render render-fn}))]
-      (js/ReactDOM.render (component) container)
+                      (this-as this (react-dom-factories/div
+                                      (clj->js {:id id}) children)))
+          component (react/createFactory (create-react-class #js {:render render-fn}))]
+      (react-dom/render (component) container)
       (let [html (.-innerHTML (goog.dom/getElement (str id)))]
         (goog.dom/removeNode container)
         (-> html

--- a/test/kioo/test_runner.cljs
+++ b/test/kioo/test_runner.cljs
@@ -1,7 +1,9 @@
 (ns kioo.test-runner
-  (:require [doo.runner :refer-macros [doo-all-tests]]
+  (:require [doo.runner :refer-macros [doo-all-tests doo-tests]]
             [kioo.core-test]
             [kioo.reagent-test]
             [kioo.om-test]))
 
-(doo-all-tests)
+(doo-tests 'kioo.core-test
+           'kioo.reagent-test
+           'kioo.om-test)


### PR DESCRIPTION
I have changed the code so that instead of React.CreateClass() and React.DOM.* it uses the drop in replacements create-react-class and react-dom-factories.

I also had to update the unit tests and change the execution engine to chrome-headless instead of phantom (which throws an exception for ECMAScript 6 code).

The cljsjs dependencies are only included for the externs. not sure if we need them since I added :infer-externs true.

Resolves #75 